### PR TITLE
Handle full base URLs for tracking scripts

### DIFF
--- a/src/Controllers/Controller.php
+++ b/src/Controllers/Controller.php
@@ -52,8 +52,40 @@ class Controller {
         header('Access-Control-Allow-Methods: GET, POST, OPTIONS');
         header('Access-Control-Allow-Headers: Content-Type');
         header('Access-Control-Max-Age: 86400');
-        
+
         header('Content-Type: application/json');
         echo json_encode($data);
+    }
+
+    protected function getBaseUrl(?array $settings = null): string {
+        if ($settings === null) {
+            $settings = $this->getSettings();
+        }
+
+        if (!empty($settings['app_url'])) {
+            return rtrim($settings['app_url'], '/');
+        }
+
+        $scheme = 'http';
+
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $forwardedProto = explode(',', $_SERVER['HTTP_X_FORWARDED_PROTO']);
+            $scheme = trim($forwardedProto[0]);
+        } elseif (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            $scheme = 'https';
+        }
+
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+
+        if ($host === '') {
+            $host = $_SERVER['SERVER_NAME'] ?? 'localhost';
+            $port = $_SERVER['SERVER_PORT'] ?? null;
+
+            if ($port && !in_array($port, ['80', '443'], true)) {
+                $host .= ':' . $port;
+            }
+        }
+
+        return rtrim($scheme . '://' . $host, '/');
     }
 }

--- a/src/Controllers/ProgramsController.php
+++ b/src/Controllers/ProgramsController.php
@@ -57,19 +57,21 @@ class ProgramsController extends Controller {
             'status' => 'active'
         ];
     
+        $baseUrl = $this->getBaseUrl();
+
         try {
-            Database::transaction(function() use ($data) {
+            Database::transaction(function() use ($data, $baseUrl) {
                 // Insert the program
                 $id = Database::insert('programs', $data);
-                
+
                 // Get the created program
                 $program = Database::query(
                     "SELECT * FROM programs WHERE id = ?",
                     [$id]
                 )->fetch();
-                
+
                 // Generate tracking script
-                ProgramScriptGenerator::generate($program, $_SERVER['HTTP_HOST']);
+                ProgramScriptGenerator::generate($program, $baseUrl);
             });
     
             $_SESSION['success'] = 'Program created successfully.';
@@ -114,13 +116,14 @@ class ProgramsController extends Controller {
         }
 
         // Get settings for the app URL
-        $appUrlSetting = Database::query("SELECT * FROM settings WHERE name = 'app_url' LIMIT 1")->fetch();
         $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings);
 
         $this->view('programs/integration', [
             'title' => 'Integration Guide - ' . ($settings['custom_app_name'] ?? 'Numok'),
             'program' => $program,
-            'settings' => $appUrlSetting
+            'settings' => $settings,
+            'baseUrl' => $baseUrl
         ]);
     }
 
@@ -156,19 +159,21 @@ class ProgramsController extends Controller {
             'status' => $_POST['status'] ?? 'active'
         ];
 
+        $baseUrl = $this->getBaseUrl();
+
         try {
-            Database::transaction(function() use ($id, $data) {
+            Database::transaction(function() use ($id, $data, $baseUrl) {
                 // Update program
                 Database::update('programs', $data, 'id = ?', [$id]);
-                
+
                 // Get updated program data for script generation
                 $program = Database::query(
                     "SELECT * FROM programs WHERE id = ?",
                     [$id]
                 )->fetch();
-                
+
                 // Generate tracking script
-                ProgramScriptGenerator::generate($program, $_SERVER['HTTP_HOST']);
+                ProgramScriptGenerator::generate($program, $baseUrl);
             });
 
             $_SESSION['success'] = 'Program updated successfully.';

--- a/src/Controllers/TrackingController.php
+++ b/src/Controllers/TrackingController.php
@@ -3,6 +3,7 @@
 namespace Numok\Controllers;
 
 use Numok\Database\Database;
+use Numok\Services\ProgramScriptGenerator;
 
 class TrackingController extends Controller {
     public function script(int $programId): void {
@@ -24,10 +25,16 @@ class TrackingController extends Controller {
         // Set CORS headers to allow the script to be loaded from any domain
         header('Access-Control-Allow-Origin: *');
         header('Access-Control-Allow-Methods: GET');
-        
+
         // Cache control - might want to adjust this in production
         header('Cache-Control: public, max-age=3600'); // 1 hour cache
         header('Vary: Origin');
+
+        $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings);
+
+        // Ensure tracking script is generated with the right base URL
+        ProgramScriptGenerator::generate($program, $baseUrl);
 
         // Get the script content
         $scriptPath = ROOT_PATH . '/public/assets/js/numok-tracking.js';
@@ -39,7 +46,7 @@ class TrackingController extends Controller {
 
         // Output the script with program ID
         echo sprintf("const NUMOK_PROGRAM_ID = %d;\n", $programId);
-        echo sprintf("const NUMOK_BASE_URL = '%s';\n", rtrim($settings['app_url'] ?? '', '/'));
+        echo sprintf("const NUMOK_BASE_URL = '%s';\n", $baseUrl);
         echo file_get_contents($scriptPath);
     }
 

--- a/src/Services/ProgramScriptGenerator.php
+++ b/src/Services/ProgramScriptGenerator.php
@@ -3,16 +3,16 @@
 namespace Numok\Services;
 
 class ProgramScriptGenerator {
-    public static function generate(array $program, string $domain): bool {
-        // Ensure domain doesn't end with a slash
-        $domain = rtrim($domain, '/');
-        
+    public static function generate(array $program, string $baseUrl): bool {
+        // Ensure base URL doesn't end with a slash
+        $baseUrl = rtrim($baseUrl, '/');
+
         $script = <<<JAVASCRIPT
 (function() {
     const COOKIE_NAME = 'numok_tracking';
     const COOKIE_DAYS = {$program['cookie_days']};
     const PROGRAM_ID = {$program['id']};
-    const API_DOMAIN = '{$domain}';
+    const API_BASE_URL = '{$baseUrl}';
 
     class NumokTracker {
         constructor() {
@@ -47,7 +47,7 @@ class ProgramScriptGenerator {
                 const trackingEnabled = await this.checkTrackingEnabled();
                 if (!trackingEnabled) return;
 
-                await fetch(`https://\${API_DOMAIN}/api/tracking/click`, {
+                await fetch(`\${API_BASE_URL}/api/tracking/click`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(data)
@@ -59,7 +59,7 @@ class ProgramScriptGenerator {
 
         async checkTrackingEnabled() {
             try {
-                const response = await fetch(`https://\${API_DOMAIN}/api/tracking/config/\${PROGRAM_ID}`);
+                const response = await fetch(`\${API_BASE_URL}/api/tracking/config/\${PROGRAM_ID}`);
                 const config = await response.json();
                 return config.track_clicks || false;
             } catch {

--- a/src/Views/programs/integration.php
+++ b/src/Views/programs/integration.php
@@ -34,6 +34,10 @@
     }
 </style>
 
+<?php
+    $integrationBaseUrl = rtrim($baseUrl ?? ('https://' . ($_SERVER['HTTP_HOST'] ?? 'localhost')), '/');
+?>
+
 <div class="min-h-full">
     <main>
         <div class="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8">
@@ -108,7 +112,7 @@
                         </div>
                         <div class="mt-3">
                             <div class="rounded-md bg-gray-50 p-4">
-                                <pre class="text-sm text-gray-800 whitespace-pre-wrap"><code class="language-html">&lt;script src="https://<?= $_SERVER['HTTP_HOST'] ?>/tracking/program-<?= $program['id'] ?>.js"&gt;&lt;/script&gt;</code></pre>
+                                <pre class="text-sm text-gray-800 whitespace-pre-wrap"><code class="language-html">&lt;script src="<?= htmlspecialchars($integrationBaseUrl) ?>/tracking/program-<?= $program['id'] ?>.js"&gt;&lt;/script&gt;</code></pre>
                             </div>
                         </div>
                         <div class="mt-3 text-sm">
@@ -318,7 +322,7 @@ numok_sid3: tracking_data['sid3']
                         <div class="mt-3">
                             <div class="rounded-md bg-gray-50 p-4">
                                 <h4 class="text-sm font-medium text-gray-900">Webhook URL</h4>
-                                <pre class="mt-2 text-sm text-gray-800"><?= rtrim('https://'.$_SERVER['HTTP_HOST'], '/') ?>/webhook/stripe</pre>
+                                <pre class="mt-2 text-sm text-gray-800"><?= htmlspecialchars($integrationBaseUrl) ?>/webhook/stripe</pre>
 
                                 <h4 class="mt-4 text-sm font-medium text-gray-900">Required Events</h4>
                                 <ul class="mt-2 list-disc pl-5 text-sm text-gray-600 space-y-1">


### PR DESCRIPTION
## Summary
- add a reusable helper to determine the application base URL from settings or the active request
- update tracking script generation and admin workflows to consume the computed base URL
- refresh the integration guide so embed snippets display URLs with the proper scheme

## Testing
- php -l src/Controllers/Controller.php
- php -l src/Controllers/TrackingController.php
- php -l src/Controllers/ProgramsController.php
- php -l src/Services/ProgramScriptGenerator.php
- php -l src/Views/programs/integration.php

------
https://chatgpt.com/codex/tasks/task_e_68d1afaaca5083219c64e7490614ab78