### PR TITLE
Add app URL and click tracking settings

### DIFF
--- a/src/Controllers/ProgramsController.php
+++ b/src/Controllers/ProgramsController.php
@@ -113,14 +113,12 @@ class ProgramsController extends Controller {
             exit;
         }
 
-        // Get settings for the app URL
-        $appUrlSetting = Database::query("SELECT * FROM settings WHERE name = 'app_url' LIMIT 1")->fetch();
         $settings = $this->getSettings();
 
         $this->view('programs/integration', [
             'title' => 'Integration Guide - ' . ($settings['custom_app_name'] ?? 'Numok'),
             'program' => $program,
-            'settings' => $appUrlSetting
+            'settings' => $settings
         ]);
     }
 

--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -32,18 +32,48 @@ class SettingsController extends Controller {
         }
 
         try {
-            Database::transaction(function() {
-                $settings = [
-                    'app_name' => $_POST['app_name'] ?? 'Numok',
-                    'partner_welcome_message' => $_POST['partner_welcome_message'] ?? '',
-                    'stripe_secret_key' => $_POST['stripe_secret_key'] ?? '',
-                    'stripe_webhook_secret' => $_POST['stripe_webhook_secret'] ?? ''
-                ];
+            $settingsToUpdate = [];
 
-                foreach ($settings as $key => $value) {
+            if (array_key_exists('app_name', $_POST)) {
+                $appName = trim((string)$_POST['app_name']);
+                $settingsToUpdate['app_name'] = $appName !== '' ? $appName : 'Numok';
+            }
+
+            if (array_key_exists('partner_welcome_message', $_POST)) {
+                $settingsToUpdate['partner_welcome_message'] = trim((string)$_POST['partner_welcome_message']);
+            }
+
+            if (array_key_exists('stripe_secret_key', $_POST)) {
+                $settingsToUpdate['stripe_secret_key'] = trim((string)$_POST['stripe_secret_key']);
+            }
+
+            if (array_key_exists('stripe_webhook_secret', $_POST)) {
+                $settingsToUpdate['stripe_webhook_secret'] = trim((string)$_POST['stripe_webhook_secret']);
+            }
+
+            if (array_key_exists('app_url', $_POST)) {
+                $appUrl = trim((string)$_POST['app_url']);
+
+                if ($appUrl !== '' && !filter_var($appUrl, FILTER_VALIDATE_URL)) {
+                    throw new \InvalidArgumentException('Please provide a valid application URL.');
+                }
+
+                $settingsToUpdate['app_url'] = rtrim($appUrl, '/');
+            }
+
+            if (array_key_exists('click_tracking_enabled', $_POST)) {
+                $settingsToUpdate['click_tracking_enabled'] = $_POST['click_tracking_enabled'] === '1' ? '1' : '0';
+            }
+
+            if (empty($settingsToUpdate)) {
+                throw new \RuntimeException('No settings were provided for update.');
+            }
+
+            Database::transaction(function() use ($settingsToUpdate) {
+                foreach ($settingsToUpdate as $key => $value) {
                     Database::query(
-                        "INSERT INTO settings (name, value) 
-                         VALUES (?, ?) 
+                        "INSERT INTO settings (name, value)
+                         VALUES (?, ?)
                          ON DUPLICATE KEY UPDATE value = VALUES(value)",
                         [$key, $value]
                     );
@@ -51,6 +81,8 @@ class SettingsController extends Controller {
             });
 
             $_SESSION['settings_success'] = 'Settings updated successfully.';
+        } catch (\InvalidArgumentException $e) {
+            $_SESSION['settings_error'] = $e->getMessage();
         } catch (\Exception $e) {
             $_SESSION['settings_error'] = 'Failed to update settings. Please try again.';
         }

--- a/src/Controllers/TrackingController.php
+++ b/src/Controllers/TrackingController.php
@@ -18,13 +18,16 @@ class TrackingController extends Controller {
             exit;
         }
 
+        // Get global settings for the app URL and tracking configuration
+        $settings = $this->getSettings();
+
         // Set JavaScript content type
         header('Content-Type: application/javascript');
-        
+
         // Set CORS headers to allow the script to be loaded from any domain
         header('Access-Control-Allow-Origin: *');
         header('Access-Control-Allow-Methods: GET');
-        
+
         // Cache control - might want to adjust this in production
         header('Cache-Control: public, max-age=3600'); // 1 hour cache
         header('Vary: Origin');
@@ -38,8 +41,14 @@ class TrackingController extends Controller {
         }
 
         // Output the script with program ID
+        $baseUrl = rtrim($settings['app_url'] ?? '', '/');
+        if ($baseUrl === '') {
+            $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+            $baseUrl = rtrim($scheme . ($_SERVER['HTTP_HOST'] ?? ''), '/');
+        }
+
         echo sprintf("const NUMOK_PROGRAM_ID = %d;\n", $programId);
-        echo sprintf("const NUMOK_BASE_URL = '%s';\n", rtrim($settings['app_url'] ?? '', '/'));
+        echo sprintf("const NUMOK_BASE_URL = '%s';\n", $baseUrl);
         echo file_get_contents($scriptPath);
     }
 

--- a/src/Views/programs/integration.php
+++ b/src/Views/programs/integration.php
@@ -34,6 +34,15 @@
     }
 </style>
 
+<?php
+    $appUrl = trim($settings['app_url'] ?? '');
+    if ($appUrl === '') {
+        $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+        $appUrl = $scheme . ($_SERVER['HTTP_HOST'] ?? '');
+    }
+    $appUrl = rtrim($appUrl, '/');
+?>
+
 <div class="min-h-full">
     <main>
         <div class="mx-auto max-w-7xl py-6 sm:px-6 lg:px-8">
@@ -108,7 +117,7 @@
                         </div>
                         <div class="mt-3">
                             <div class="rounded-md bg-gray-50 p-4">
-                                <pre class="text-sm text-gray-800 whitespace-pre-wrap"><code class="language-html">&lt;script src="https://<?= $_SERVER['HTTP_HOST'] ?>/tracking/program-<?= $program['id'] ?>.js"&gt;&lt;/script&gt;</code></pre>
+                                <pre class="text-sm text-gray-800 whitespace-pre-wrap"><code class="language-html">&lt;script src="<?= htmlspecialchars($appUrl) ?>/tracking/program-<?= $program['id'] ?>.js"&gt;&lt;/script&gt;</code></pre>
                             </div>
                         </div>
                         <div class="mt-3 text-sm">
@@ -318,7 +327,7 @@ numok_sid3: tracking_data['sid3']
                         <div class="mt-3">
                             <div class="rounded-md bg-gray-50 p-4">
                                 <h4 class="text-sm font-medium text-gray-900">Webhook URL</h4>
-                                <pre class="mt-2 text-sm text-gray-800"><?= rtrim('https://'.$_SERVER['HTTP_HOST'], '/') ?>/webhook/stripe</pre>
+                                <pre class="mt-2 text-sm text-gray-800"><?= htmlspecialchars($appUrl) ?>/webhook/stripe</pre>
 
                                 <h4 class="mt-4 text-sm font-medium text-gray-900">Required Events</h4>
                                 <ul class="mt-2 list-disc pl-5 text-sm text-gray-600 space-y-1">

--- a/src/Views/settings/index.php
+++ b/src/Views/settings/index.php
@@ -1,5 +1,7 @@
 <?php
 // src/Views/settings/index.php
+$defaultScheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https://' : 'http://';
+$resolvedAppUrl = rtrim(trim($settings['app_url'] ?? '') ?: $defaultScheme . ($_SERVER['HTTP_HOST'] ?? ''), '/');
 ?>
 <div class="py-6">
     <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
@@ -175,17 +177,37 @@
                         <div class="mt-4 space-y-4 max-w-xl">
                             <form action="/admin/settings/update" method="POST">
                                 <div class="mb-4">
+                                    <label for="app_url" class="block text-sm font-medium text-gray-700">Application URL</label>
+                                    <input type="url" name="app_url" id="app_url"
+                                           value="<?= htmlspecialchars($settings['app_url'] ?? '') ?>"
+                                           placeholder="https://yourapp.com"
+                                           class="mt-1 block w-full rounded-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 px-3">
+                                    <p class="mt-2 text-sm text-gray-500">Used to generate integration and webhook URLs.</p>
+                                </div>
+
+                                <div class="mb-4">
                                     <label for="stripe_secret_key" class="block text-sm font-medium text-gray-700">Secret Key</label>
-                                    <input type="password" name="stripe_secret_key" id="stripe_secret_key" 
+                                    <input type="password" name="stripe_secret_key" id="stripe_secret_key"
                                            value="<?= htmlspecialchars($settings['stripe_secret_key'] ?? '') ?>"
                                            class="mt-1 block w-full rounded-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 px-3">
                                 </div>
                                 
                                 <div class="mb-4">
                                     <label for="stripe_webhook_secret" class="block text-sm font-medium text-gray-700">Webhook Secret</label>
-                                    <input type="password" name="stripe_webhook_secret" id="stripe_webhook_secret" 
+                                    <input type="password" name="stripe_webhook_secret" id="stripe_webhook_secret"
                                            value="<?= htmlspecialchars($settings['stripe_webhook_secret'] ?? '') ?>"
                                            class="mt-1 block w-full rounded-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 px-3">
+                                </div>
+
+                                <div class="mb-4">
+                                    <span class="block text-sm font-medium text-gray-700">Click Tracking</span>
+                                    <div class="mt-2 flex items-center">
+                                        <input type="hidden" name="click_tracking_enabled" value="0">
+                                        <input type="checkbox" name="click_tracking_enabled" id="click_tracking_enabled" value="1"
+                                               <?= !empty($settings['click_tracking_enabled']) ? 'checked' : '' ?>
+                                               class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                        <label for="click_tracking_enabled" class="ml-2 text-sm text-gray-600">Enable click tracking for affiliate links</label>
+                                    </div>
                                 </div>
 
                                 <template x-if="testResults?.messages">
@@ -288,7 +310,7 @@
                                     <li>Go to your <a href="https://dashboard.stripe.com/apikeys" class="text-indigo-600 hover:text-indigo-500" target="_blank">Stripe Dashboard</a></li>
                                     <li>Copy your Secret Key</li>
                                     <li>Create a new webhook endpoint pointing to:
-                                        <code class="block mt-1 p-2 bg-gray-50 rounded text-xs"><?= htmlspecialchars(rtrim($settings['app_url'] ?? 'https://'.$_SERVER['HTTP_HOST'], '/') . '/webhook/stripe') ?></code>
+                                        <code class="block mt-1 p-2 bg-gray-50 rounded text-xs"><?= htmlspecialchars($resolvedAppUrl . '/webhook/stripe') ?></code>
                                     </li>
                                     <li>Copy the webhook signing secret</li>
                                 </ol>


### PR DESCRIPTION
## Summary
- add inputs on the settings page so admins can manage the public app URL and enable or disable click tracking
- validate and persist the new settings alongside the existing ones, and ensure the integration and tracking views resolve the base URL from settings

## Testing
- php -l src/Controllers/SettingsController.php
- php -l src/Controllers/TrackingController.php
- php -l src/Controllers/ProgramsController.php
- php -l src/Views/programs/integration.php
- php -l src/Views/settings/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d1afaca9148321ac16db84800dcd34