### PR TITLE
Fix tracking routes and schema gaps

### DIFF
--- a/database/deploy.sql
+++ b/database/deploy.sql
@@ -30,6 +30,28 @@ CREATE TABLE `clicks` (
 
 
 
+# Dump of table impressions
+# ------------------------------------------------------------
+
+DROP TABLE IF EXISTS `impressions`;
+
+CREATE TABLE `impressions` (
+  `id` int unsigned NOT NULL AUTO_INCREMENT,
+  `program_id` int unsigned NOT NULL,
+  `tracking_code` varchar(50) COLLATE utf8mb4_unicode_ci NOT NULL,
+  `url` varchar(255) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `ip_address` varchar(45) COLLATE utf8mb4_unicode_ci DEFAULT NULL,
+  `user_agent` text COLLATE utf8mb4_unicode_ci,
+  `created_at` timestamp NULL DEFAULT CURRENT_TIMESTAMP,
+  PRIMARY KEY (`id`),
+  KEY `program_id` (`program_id`),
+  KEY `idx_impressions_tracking_code` (`tracking_code`),
+  CONSTRAINT `impressions_ibfk_1` FOREIGN KEY (`program_id`) REFERENCES `programs` (`id`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+
+
+
 # Dump of table conversions
 # ------------------------------------------------------------
 

--- a/docker/init-admin.sql
+++ b/docker/init-admin.sql
@@ -23,5 +23,6 @@ INSERT INTO settings (name, value) VALUES
 ('stripe_webhook_secret', ''),
 ('commission_rate', '10.00'),
 ('cookie_duration', '30'),
-('payout_threshold', '100.00')
+('payout_threshold', '100.00'),
+('click_tracking_enabled', '0')
 ON DUPLICATE KEY UPDATE name=name;

--- a/public/index.php
+++ b/public/index.php
@@ -34,7 +34,6 @@ $routes = [
     'settings/update' => ['PartnerProfileController', 'update'],
     'logout' => ['PartnerAuthController', 'logout'],
     'dashboard' => ['PartnerDashboardController', 'index'],
-    'tracking' => ['PartnerTrackingController', 'index'],
     'earnings' => ['PartnerEarningsController', 'index'],
     'programs' => ['PartnerProgramsController', 'index'],
     'programs/join' => ['PartnerProgramsController', 'join'],
@@ -75,11 +74,15 @@ $routes = [
     'admin/conversions/update-status' => ['ConversionsController', 'updateStatus'],
     'admin/conversions/export' => ['ConversionsController', 'export'],
 
-    // API routes  
+    // Tracking script route
+    'tracking/program-(\d+)\.js' => ['TrackingController', 'script'],
+
+    // API routes
     'api/health' => ['HealthController', 'health'],
     'api/ready' => ['HealthController', 'ready'],
     'api/tracking/config/(\d+)' => ['TrackingController', 'config'],
     'api/tracking/click' => ['TrackingController', 'click'],
+    'api/tracking/impression' => ['TrackingController', 'impression'],
 
     // Webhook routes
     'webhook/stripe' => ['WebhookController', 'stripeWebhook'],

--- a/src/Controllers/TrackingController.php
+++ b/src/Controllers/TrackingController.php
@@ -3,10 +3,10 @@
 namespace Numok\Controllers;
 
 use Numok\Database\Database;
+use Numok\Services\ProgramScriptGenerator;
 
 class TrackingController extends Controller {
     public function script(int $programId): void {
-        // Get program
         $program = Database::query(
             "SELECT * FROM programs WHERE id = ? AND status = 'active' LIMIT 1",
             [$programId]
@@ -18,28 +18,46 @@ class TrackingController extends Controller {
             exit;
         }
 
-        // Set JavaScript content type
-        header('Content-Type: application/javascript');
-        
-        // Set CORS headers to allow the script to be loaded from any domain
-        header('Access-Control-Allow-Origin: *');
-        header('Access-Control-Allow-Methods: GET');
-        
-        // Cache control - might want to adjust this in production
-        header('Cache-Control: public, max-age=3600'); // 1 hour cache
-        header('Vary: Origin');
+        $settings = $this->getSettings();
+        $appUrl = $settings['app_url'] ?? '';
 
-        // Get the script content
-        $scriptPath = ROOT_PATH . '/public/assets/js/numok-tracking.js';
-        if (!file_exists($scriptPath)) {
+        $domain = '';
+        if (!empty($appUrl)) {
+            $parsed = parse_url($appUrl);
+            if (!empty($parsed['host'])) {
+                $domain = $parsed['host'];
+                if (!empty($parsed['port'])) {
+                    $domain .= ':' . $parsed['port'];
+                }
+            } else {
+                $domain = preg_replace('#^https?://#', '', trim($appUrl));
+            }
+        }
+
+        if (empty($domain) && !empty($_SERVER['HTTP_HOST'])) {
+            $domain = $_SERVER['HTTP_HOST'];
+        }
+
+        if (empty($domain)) {
+            $domain = 'localhost';
+        }
+
+        $domain = rtrim($domain, '/');
+
+        $scriptPath = ROOT_PATH . "/public/tracking/program-{$programId}.js";
+
+        if (!ProgramScriptGenerator::generate($program, $domain) || !file_exists($scriptPath)) {
             header("HTTP/1.0 500 Internal Server Error");
-            echo "Tracking script not found";
+            echo "Tracking script not available";
             exit;
         }
 
-        // Output the script with program ID
-        echo sprintf("const NUMOK_PROGRAM_ID = %d;\n", $programId);
-        echo sprintf("const NUMOK_BASE_URL = '%s';\n", rtrim($settings['app_url'] ?? '', '/'));
+        header('Content-Type: application/javascript');
+        header('Access-Control-Allow-Origin: *');
+        header('Access-Control-Allow-Methods: GET');
+        header('Cache-Control: public, max-age=3600');
+        header('Vary: Origin');
+
         echo file_get_contents($scriptPath);
     }
 
@@ -63,7 +81,7 @@ class TrackingController extends Controller {
         // Format settings
         $config = [
             'cookie_days' => (int)$program['cookie_days'],
-            'track_clicks' => !empty($settings['value'])
+            'track_clicks' => !empty($settings['value'] ?? null)
         ];
 
         // Return JSON response


### PR DESCRIPTION
## Summary
- remove the unused partner /tracking route and register a script endpoint plus the impression API route
- regenerate tracking scripts from the controller using ProgramScriptGenerator with better domain detection
- add the impressions table to the schema and seed click_tracking_enabled in the default settings

## Testing
- php -l src/Controllers/TrackingController.php
- php -l public/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d19b87fadc8321b2888bed9c74cac9