### PR TITLE
Improve base URL handling for tracking scripts

### DIFF
--- a/src/Controllers/Controller.php
+++ b/src/Controllers/Controller.php
@@ -22,12 +22,84 @@ class Controller {
         if (!isset($data['settings'])) {
             $data['settings'] = $this->getSettings();
         }
-        
+
         extract($data);
-        
+
         require ROOT_PATH . "/src/Views/layouts/header.php";
         require ROOT_PATH . "/src/Views/{$template}.php";
         require ROOT_PATH . "/src/Views/layouts/footer.php";
+    }
+
+    protected function getBaseUrl(?string $appUrl = null): string {
+        $appUrl = $appUrl !== null ? trim($appUrl) : '';
+
+        if ($appUrl !== '') {
+            $normalized = rtrim($appUrl, '/');
+            $parsed = parse_url($normalized);
+
+            if (!empty($parsed['scheme']) && !empty($parsed['host'])) {
+                $host = $parsed['host'];
+                if (!empty($parsed['port'])) {
+                    $host .= ':' . $parsed['port'];
+                }
+
+                return sprintf('%s://%s', $parsed['scheme'], $host);
+            }
+
+            $host = $parsed['host'] ?? '';
+            if ($host === '' && !empty($parsed['path'])) {
+                $host = ltrim($parsed['path'], '/');
+            }
+
+            if ($host !== '') {
+                if (strpos($host, '/') !== false) {
+                    $host = substr($host, 0, strpos($host, '/'));
+                }
+
+                return sprintf('%s://%s', $this->detectRequestScheme(), $host);
+            }
+        }
+
+        $scheme = $this->detectRequestScheme();
+        $host = $_SERVER['HTTP_HOST'] ?? '';
+
+        if ($host === '' && !empty($_SERVER['SERVER_NAME'])) {
+            $host = $_SERVER['SERVER_NAME'];
+            $port = $_SERVER['SERVER_PORT'] ?? null;
+            if ($port && !in_array((int)$port, [80, 443], true) && strpos($host, ':') === false) {
+                $host .= ':' . $port;
+            }
+        }
+
+        if ($host === '') {
+            $host = 'localhost';
+            $port = $_SERVER['SERVER_PORT'] ?? null;
+            if ($port && !in_array((int)$port, [80, 443], true)) {
+                $host .= ':' . $port;
+            }
+        }
+
+        return sprintf('%s://%s', $scheme, rtrim($host, '/'));
+    }
+
+    protected function detectRequestScheme(): string {
+        if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+            $forwarded = explode(',', $_SERVER['HTTP_X_FORWARDED_PROTO']);
+            $proto = strtolower(trim($forwarded[0]));
+            if ($proto !== '') {
+                return $proto;
+            }
+        }
+
+        if (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') {
+            return 'https';
+        }
+
+        if (!empty($_SERVER['REQUEST_SCHEME'])) {
+            return strtolower($_SERVER['REQUEST_SCHEME']);
+        }
+
+        return 'http';
     }
 
     protected function getSettings(): array {

--- a/src/Controllers/ProgramsController.php
+++ b/src/Controllers/ProgramsController.php
@@ -56,22 +56,24 @@ class ProgramsController extends Controller {
             'landing_page' => $_POST['landing_page'] ?? '',
             'status' => 'active'
         ];
-    
+
+        $baseUrl = $this->getBaseUrl(($this->getSettings()['app_url'] ?? null));
+
         try {
-            Database::transaction(function() use ($data) {
+            Database::transaction(function() use ($data, $baseUrl) {
                 // Insert the program
                 $id = Database::insert('programs', $data);
-                
+
                 // Get the created program
                 $program = Database::query(
                     "SELECT * FROM programs WHERE id = ?",
                     [$id]
                 )->fetch();
-                
+
                 // Generate tracking script
-                ProgramScriptGenerator::generate($program, $_SERVER['HTTP_HOST']);
+                ProgramScriptGenerator::generate($program, $baseUrl);
             });
-    
+
             $_SESSION['success'] = 'Program created successfully.';
         } catch (\Exception $e) {
             error_log("Failed to create program: " . $e->getMessage());
@@ -116,11 +118,14 @@ class ProgramsController extends Controller {
         // Get settings for the app URL
         $appUrlSetting = Database::query("SELECT * FROM settings WHERE name = 'app_url' LIMIT 1")->fetch();
         $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings['app_url'] ?? null);
 
         $this->view('programs/integration', [
             'title' => 'Integration Guide - ' . ($settings['custom_app_name'] ?? 'Numok'),
             'program' => $program,
-            'settings' => $appUrlSetting
+            'settings' => $settings,
+            'appUrlSetting' => $appUrlSetting,
+            'baseUrl' => $baseUrl
         ]);
     }
 
@@ -156,19 +161,22 @@ class ProgramsController extends Controller {
             'status' => $_POST['status'] ?? 'active'
         ];
 
+        $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings['app_url'] ?? null);
+
         try {
-            Database::transaction(function() use ($id, $data) {
+            Database::transaction(function() use ($id, $data, $baseUrl) {
                 // Update program
                 Database::update('programs', $data, 'id = ?', [$id]);
-                
+
                 // Get updated program data for script generation
                 $program = Database::query(
                     "SELECT * FROM programs WHERE id = ?",
                     [$id]
                 )->fetch();
-                
+
                 // Generate tracking script
-                ProgramScriptGenerator::generate($program, $_SERVER['HTTP_HOST']);
+                ProgramScriptGenerator::generate($program, $baseUrl);
             });
 
             $_SESSION['success'] = 'Program updated successfully.';

--- a/src/Controllers/TrackingController.php
+++ b/src/Controllers/TrackingController.php
@@ -19,34 +19,11 @@ class TrackingController extends Controller {
         }
 
         $settings = $this->getSettings();
-        $appUrl = $settings['app_url'] ?? '';
-
-        $domain = '';
-        if (!empty($appUrl)) {
-            $parsed = parse_url($appUrl);
-            if (!empty($parsed['host'])) {
-                $domain = $parsed['host'];
-                if (!empty($parsed['port'])) {
-                    $domain .= ':' . $parsed['port'];
-                }
-            } else {
-                $domain = preg_replace('#^https?://#', '', trim($appUrl));
-            }
-        }
-
-        if (empty($domain) && !empty($_SERVER['HTTP_HOST'])) {
-            $domain = $_SERVER['HTTP_HOST'];
-        }
-
-        if (empty($domain)) {
-            $domain = 'localhost';
-        }
-
-        $domain = rtrim($domain, '/');
+        $baseUrl = $this->getBaseUrl($settings['app_url'] ?? null);
 
         $scriptPath = ROOT_PATH . "/public/tracking/program-{$programId}.js";
 
-        if (!ProgramScriptGenerator::generate($program, $domain) || !file_exists($scriptPath)) {
+        if (!ProgramScriptGenerator::generate($program, $baseUrl) || !file_exists($scriptPath)) {
             header("HTTP/1.0 500 Internal Server Error");
             echo "Tracking script not available";
             exit;

--- a/src/Services/ProgramScriptGenerator.php
+++ b/src/Services/ProgramScriptGenerator.php
@@ -3,16 +3,16 @@
 namespace Numok\Services;
 
 class ProgramScriptGenerator {
-    public static function generate(array $program, string $domain): bool {
-        // Ensure domain doesn't end with a slash
-        $domain = rtrim($domain, '/');
+    public static function generate(array $program, string $baseUrl): bool {
+        // Ensure base URL doesn't end with a slash
+        $baseUrl = rtrim($baseUrl, '/');
         
         $script = <<<JAVASCRIPT
 (function() {
     const COOKIE_NAME = 'numok_tracking';
     const COOKIE_DAYS = {$program['cookie_days']};
     const PROGRAM_ID = {$program['id']};
-    const API_DOMAIN = '{$domain}';
+    const API_BASE_URL = '{$baseUrl}';
 
     class NumokTracker {
         constructor() {
@@ -47,7 +47,7 @@ class ProgramScriptGenerator {
                 const trackingEnabled = await this.checkTrackingEnabled();
                 if (!trackingEnabled) return;
 
-                await fetch(`https://\${API_DOMAIN}/api/tracking/click`, {
+                await fetch(`\${API_BASE_URL}/api/tracking/click`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify(data)
@@ -59,7 +59,7 @@ class ProgramScriptGenerator {
 
         async checkTrackingEnabled() {
             try {
-                const response = await fetch(`https://\${API_DOMAIN}/api/tracking/config/\${PROGRAM_ID}`);
+                const response = await fetch(`\${API_BASE_URL}/api/tracking/config/\${PROGRAM_ID}`);
                 const config = await response.json();
                 return config.track_clicks || false;
             } catch {

--- a/src/Views/programs/integration.php
+++ b/src/Views/programs/integration.php
@@ -107,8 +107,25 @@
                             <p>Add this script to every page of your website to track affiliate referrals. Place it in the <code>&lt;head&gt;</code> section:</p>
                         </div>
                         <div class="mt-3">
+                            <?php
+                            $resolvedBaseUrl = isset($baseUrl) ? rtrim($baseUrl, '/') : '';
+                            if ($resolvedBaseUrl === '' && !empty($_SERVER['HTTP_HOST'])) {
+                                if (!empty($_SERVER['HTTP_X_FORWARDED_PROTO'])) {
+                                    $forwardedProtoParts = explode(',', $_SERVER['HTTP_X_FORWARDED_PROTO']);
+                                    $scheme = strtolower(trim($forwardedProtoParts[0]));
+                                    $scheme = $scheme !== '' ? $scheme : 'http';
+                                } else {
+                                    $scheme = (!empty($_SERVER['HTTPS']) && $_SERVER['HTTPS'] !== 'off') ? 'https' : 'http';
+                                }
+                                $resolvedBaseUrl = $scheme . '://' . trim($_SERVER['HTTP_HOST'], '/');
+                            }
+                            if ($resolvedBaseUrl === '') {
+                                $resolvedBaseUrl = 'http://localhost';
+                            }
+                            $trackingScriptUrl = rtrim($resolvedBaseUrl, '/') . '/tracking/program-' . $program['id'] . '.js';
+                            ?>
                             <div class="rounded-md bg-gray-50 p-4">
-                                <pre class="text-sm text-gray-800 whitespace-pre-wrap"><code class="language-html">&lt;script src="https://<?= $_SERVER['HTTP_HOST'] ?>/tracking/program-<?= $program['id'] ?>.js"&gt;&lt;/script&gt;</code></pre>
+                                <pre class="text-sm text-gray-800 whitespace-pre-wrap"><code class="language-html">&lt;script src="<?= htmlspecialchars($trackingScriptUrl, ENT_QUOTES) ?>"&gt;&lt;/script&gt;</code></pre>
                             </div>
                         </div>
                         <div class="mt-3 text-sm">


### PR DESCRIPTION
## Summary
- add a shared helper to resolve the application base URL from configuration or the current request
- ensure tracking and program controllers pass the full base URL into the script generator and integration view
- update the tracking script generator and integration snippet to reuse the provided base URL instead of forcing HTTPS

## Testing
- php -l src/Controllers/Controller.php
- php -l src/Controllers/TrackingController.php
- php -l src/Controllers/ProgramsController.php
- php -l src/Services/ProgramScriptGenerator.php
- php -l src/Views/programs/integration.php

------
https://chatgpt.com/codex/tasks/task_e_68d1cdad9d588321bd27ad35736fdd0b