### PR TITLE
Add app URL and click tracking settings management

### DIFF
--- a/src/Controllers/SettingsController.php
+++ b/src/Controllers/SettingsController.php
@@ -32,25 +32,63 @@ class SettingsController extends Controller {
         }
 
         try {
-            Database::transaction(function() {
-                $settings = [
-                    'app_name' => $_POST['app_name'] ?? 'Numok',
-                    'partner_welcome_message' => $_POST['partner_welcome_message'] ?? '',
-                    'stripe_secret_key' => $_POST['stripe_secret_key'] ?? '',
-                    'stripe_webhook_secret' => $_POST['stripe_webhook_secret'] ?? ''
-                ];
+            $updates = [];
 
-                foreach ($settings as $key => $value) {
-                    Database::query(
-                        "INSERT INTO settings (name, value) 
-                         VALUES (?, ?) 
-                         ON DUPLICATE KEY UPDATE value = VALUES(value)",
-                        [$key, $value]
-                    );
+            if (array_key_exists('app_name', $_POST)) {
+                $appName = trim((string)$_POST['app_name']);
+                $updates['app_name'] = $appName !== '' ? $appName : 'Numok';
+            }
+
+            if (array_key_exists('partner_welcome_message', $_POST)) {
+                $updates['partner_welcome_message'] = trim((string)$_POST['partner_welcome_message']);
+            }
+
+            if (array_key_exists('stripe_secret_key', $_POST)) {
+                $updates['stripe_secret_key'] = trim((string)$_POST['stripe_secret_key']);
+            }
+
+            if (array_key_exists('stripe_webhook_secret', $_POST)) {
+                $updates['stripe_webhook_secret'] = trim((string)$_POST['stripe_webhook_secret']);
+            }
+
+            if (array_key_exists('app_url', $_POST)) {
+                $appUrl = trim((string)$_POST['app_url']);
+
+                if ($appUrl !== '') {
+                    if (!preg_match('/^https?:\/\//i', $appUrl)) {
+                        $appUrl = 'https://' . ltrim($appUrl, '/');
+                    }
+
+                    $appUrl = rtrim($appUrl, '/');
+
+                    if (!filter_var($appUrl, FILTER_VALIDATE_URL)) {
+                        throw new \InvalidArgumentException('Please provide a valid application URL.');
+                    }
                 }
-            });
+
+                $updates['app_url'] = $appUrl;
+            }
+
+            if (array_key_exists('click_tracking_enabled', $_POST)) {
+                $updates['click_tracking_enabled'] = $_POST['click_tracking_enabled'] === '1' ? '1' : '0';
+            }
+
+            if (!empty($updates)) {
+                Database::transaction(function() use ($updates) {
+                    foreach ($updates as $key => $value) {
+                        Database::query(
+                            "INSERT INTO settings (name, value)
+                             VALUES (?, ?)
+                             ON DUPLICATE KEY UPDATE value = VALUES(value)",
+                            [$key, $value]
+                        );
+                    }
+                });
+            }
 
             $_SESSION['settings_success'] = 'Settings updated successfully.';
+        } catch (\InvalidArgumentException $e) {
+            $_SESSION['settings_error'] = $e->getMessage();
         } catch (\Exception $e) {
             $_SESSION['settings_error'] = 'Failed to update settings. Please try again.';
         }

--- a/src/Controllers/TrackingController.php
+++ b/src/Controllers/TrackingController.php
@@ -51,14 +51,11 @@ class TrackingController extends Controller {
         }
 
         // Get tracking settings
-        $settings = Database::query(
-            "SELECT value FROM settings WHERE name = 'click_tracking_enabled'"
-        )->fetch();
+        $settings = $this->getSettings();
 
-        // Format settings
         $config = [
             'cookie_days' => (int)$program['cookie_days'],
-            'track_clicks' => !empty($settings['value'] ?? null)
+            'track_clicks' => !empty($settings['click_tracking_enabled']) && $settings['click_tracking_enabled'] !== '0'
         ];
 
         // Return JSON response

--- a/src/Views/settings/index.php
+++ b/src/Views/settings/index.php
@@ -133,12 +133,46 @@
                         </div>
                     </div>
                 </div>
+                <!-- General Application Settings -->
+                <div class="bg-white shadow sm:rounded-lg">
+                    <div class="px-4 py-5 sm:p-6">
+                        <h3 class="text-base font-semibold leading-6 text-gray-900">General Settings</h3>
+                        <div class="mt-4 max-w-xl">
+                            <form action="/admin/settings/update" method="POST">
+                                <div class="mb-4">
+                                    <label for="app_url" class="block text-sm font-medium text-gray-700">Application URL</label>
+                                    <input type="url" name="app_url" id="app_url"
+                                           value="<?= htmlspecialchars($settings['app_url'] ?? '') ?>"
+                                           placeholder="https://example.com"
+                                           class="mt-1 block w-full rounded-md border-0 py-1.5 text-gray-900 ring-1 ring-inset ring-gray-300 placeholder:text-gray-400 focus:ring-2 focus:ring-inset focus:ring-indigo-600 sm:text-sm sm:leading-6 px-3">
+                                    <p class="mt-2 text-sm text-gray-500">Used to generate tracking scripts and webhook URLs.</p>
+                                </div>
 
+                                <div class="mb-4">
+                                    <span class="block text-sm font-medium text-gray-700 mb-2">Click Tracking</span>
+                                    <div class="flex items-center">
+                                        <input type="hidden" name="click_tracking_enabled" value="0">
+                                        <input type="checkbox" id="click_tracking_enabled" name="click_tracking_enabled" value="1"
+                                               <?= (!empty($settings['click_tracking_enabled']) && $settings['click_tracking_enabled'] !== '0') ? 'checked' : '' ?>
+                                               class="h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-indigo-500">
+                                        <label for="click_tracking_enabled" class="ml-2 text-sm text-gray-600">Enable recording of partner click events.</label>
+                                    </div>
+                                </div>
 
+                                <div class="mt-6">
+                                    <button type="submit"
+                                            class="inline-flex justify-center rounded-md bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
+                                        Save General Settings
+                                    </button>
+                                </div>
+                            </form>
+                        </div>
+                    </div>
+                </div>
 
                 <!-- Stripe Integration -->
-                <div class="bg-white shadow sm:rounded-lg" x-data="{ 
-                    testResults: null, 
+                <div class="bg-white shadow sm:rounded-lg" x-data="{
+                    testResults: null,
                     testing: false,
                     async testConnection() {
                         this.testing = true;


### PR DESCRIPTION
## Summary
- add a general settings form to manage the application URL and click tracking toggle in the admin UI
- validate, normalize, and persist the new settings (without overwriting unrelated ones) alongside existing configuration values
- read the click tracking flag from stored settings when serving tracking configuration

## Testing
- php -l src/Controllers/SettingsController.php
- php -l src/Controllers/TrackingController.php
- php -l src/Views/settings/index.php

------
https://chatgpt.com/codex/tasks/task_e_68d1d11c79d88321bfca6d317ff01ff6