### PR TITLE
Fix partner program terms acceptance and webhook secret checks

### DIFF
--- a/src/Controllers/PartnerProgramsController.php
+++ b/src/Controllers/PartnerProgramsController.php
@@ -47,7 +47,7 @@ class PartnerProgramsController extends PartnerBaseController {
 
         // Validate program exists and is active
         $program = Database::query(
-            "SELECT id FROM programs WHERE id = ? AND status = 'active'",
+            "SELECT id, terms FROM programs WHERE id = ? AND status = 'active'",
             [$programId]
         )->fetch();
 
@@ -70,29 +70,23 @@ class PartnerProgramsController extends PartnerBaseController {
             exit;
         }
 
-        // Store terms acceptance details
-        if (!empty($program['terms'])) {
-            Database::update(
-                'partner_programs',
-                [
-                    'terms_accepted' => date('Y-m-d H:i:s'),
-                    'terms_accepted_ip' => $_SERVER['REMOTE_ADDR']
-                ],
-                'partner_id = ? AND program_id = ?',
-                [$partnerId, $programId]
-            );
-        }
-
         // Generate unique tracking code
         $trackingCode = bin2hex(random_bytes(8));
 
         try {
-            Database::insert('partner_programs', [
+            $insertData = [
                 'partner_id' => $partnerId,
                 'program_id' => $programId,
                 'tracking_code' => $trackingCode,
                 'status' => 'active'
-            ]);
+            ];
+
+            if (!empty($program['terms'])) {
+                $insertData['terms_accepted'] = date('Y-m-d H:i:s');
+                $insertData['terms_accepted_ip'] = $_SERVER['REMOTE_ADDR'] ?? null;
+            }
+
+            Database::insert('partner_programs', $insertData);
 
             $_SESSION['success'] = 'Successfully joined the program!';
         } catch (\Exception $e) {

--- a/src/Controllers/WebhookController.php
+++ b/src/Controllers/WebhookController.php
@@ -15,14 +15,23 @@ class WebhookController extends Controller {
         ]);
 
         // Get webhook secret from settings
-        $webhookSecret = Database::query(
+        $webhookSecretSetting = Database::query(
             "SELECT value FROM settings WHERE name = 'stripe_webhook_secret' LIMIT 1"
-        )->fetch()['value'];
+        )->fetch();
+        $webhookSecret = $webhookSecretSetting['value'] ?? null;
+
+        if (empty($webhookSecret)) {
+            $this->logEvent('webhook_missing_secret', [
+                'error' => 'Stripe webhook secret not configured'
+            ]);
+            http_response_code(503);
+            echo json_encode(['error' => 'Stripe webhook secret not configured']);
+            return;
+        }
 
         // Get payload and signature
-        $payload = @file_get_contents('php://input');
         $sigHeader = $_SERVER['HTTP_STRIPE_SIGNATURE'] ?? '';
-        
+
         try {
             // Verify signature
             $event = \Stripe\Webhook::constructEvent(


### PR DESCRIPTION
## Summary
- capture program terms when validating a join request so acceptance metadata is stored at insert time
- guard the Stripe webhook handler against a missing secret and return a clear error response

## Testing
- php -l src/Controllers/PartnerProgramsController.php
- php -l src/Controllers/WebhookController.php

------
https://chatgpt.com/codex/tasks/task_e_68d2cb036ee4832188a3c0c24ff341e6