### PR TITLE
Add authenticated REST API endpoints

### DIFF
--- a/config/config.example.php
+++ b/config/config.example.php
@@ -18,6 +18,12 @@ $config['app'] = [
     'debug' => getenv('APP_DEBUG') ?: true
 ];
 
+// API access configuration
+$config['api'] = [
+    // Comma separated list of tokens or hashed tokens generated with password_hash
+    'tokens' => array_filter(array_map('trim', explode(',', getenv('API_TOKENS') ?: '')))
+];
+
 // Time zone
 date_default_timezone_set('UTC');
 

--- a/public/index.php
+++ b/public/index.php
@@ -83,6 +83,14 @@ $routes = [
     'api/tracking/config/(\d+)' => ['TrackingController', 'config'],
     'api/tracking/click' => ['TrackingController', 'click'],
     'api/tracking/impression' => ['TrackingController', 'impression'],
+    'api/v1/users' => ['Api\\UsersController', 'handle'],
+    'api/v1/users/(\d+)' => ['Api\\UsersController', 'handle'],
+    'api/v1/programs' => ['Api\\ProgramsController', 'handle'],
+    'api/v1/programs/(\d+)' => ['Api\\ProgramsController', 'handle'],
+    'api/v1/partners' => ['Api\\PartnersController', 'handle'],
+    'api/v1/partners/(\d+)' => ['Api\\PartnersController', 'handle'],
+    'api/v1/partners/(\d+)/links' => ['Api\\PartnerLinksController', 'handle'],
+    'api/v1/partners/(\d+)/programs' => ['Api\\PartnerProgramsController', 'handle'],
 
     // Webhook routes
     'webhook/stripe' => ['WebhookController', 'stripeWebhook'],

--- a/readme.md
+++ b/readme.md
@@ -201,3 +201,78 @@ Support
 
 -   GitHub Issues: Report bugs and feature requests
 -   Documentation: https://numok.com
+
+## REST API
+
+Numok ships with an authenticated HTTP API that makes it possible to manage the platform from other services. All endpoints live under `/api/v1/*` and require an API token.
+
+### Authentication
+
+1. Generate one or more random tokens (for example with `openssl rand -hex 32`).
+2. Add the tokens to the `API_TOKENS` environment variable (comma separated) or to the `config/config.php` file under `$config['api']['tokens']`.
+3. Send the token in an `Authorization: Bearer <token>` header or an `X-API-Key: <token>` header when calling the API.
+
+You can store hashed tokens instead of the raw token by running them through `password_hash`. The API will accept both raw and hashed values.
+
+### Available endpoints
+
+| Method | Endpoint | Description |
+| --- | --- | --- |
+| `GET` | `/api/v1/users` | List admin users. |
+| `POST` | `/api/v1/users` | Create a new user (admin or standard). |
+| `GET` | `/api/v1/users/{id}` | Retrieve a single user. |
+| `GET` | `/api/v1/programs` | List all programs (campaigns). |
+| `POST` | `/api/v1/programs` | Create a new program and regenerate its tracking script. |
+| `GET` | `/api/v1/programs/{id}` | Retrieve program details. |
+| `GET` | `/api/v1/partners` | List partners (affiliates). |
+| `POST` | `/api/v1/partners` | Create a new partner. |
+| `GET` | `/api/v1/partners/{id}` | Retrieve partner details. |
+| `GET` | `/api/v1/partners/{id}/links` | List tracking links for the partner across their programs. |
+| `GET` | `/api/v1/partners/{id}/programs` | List partner program assignments including generated URLs. |
+| `POST` | `/api/v1/partners/{id}/programs` | Assign a partner to a program (returns or creates a tracking link). |
+
+### Example requests
+
+Create a user:
+
+```bash
+curl -X POST https://your-domain.com/api/v1/users \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "email": "ops@example.com",
+        "name": "Operations",
+        "password": "super-secret",
+        "is_admin": true
+      }'
+```
+
+Create a program:
+
+```bash
+curl -X POST https://your-domain.com/api/v1/programs \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "name": "Spring campaign",
+        "description": "10% off for referrals",
+        "commission_type": "percentage",
+        "commission_value": 15,
+        "cookie_days": 30,
+        "landing_page": "https://example.com/landing"
+      }'
+```
+
+Assign a partner to a program and obtain the tracking link:
+
+```bash
+curl -X POST https://your-domain.com/api/v1/partners/12/programs \
+  -H "Authorization: Bearer <token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+        "program_id": 7,
+        "postback_url": "https://partner-site.test/postback"
+      }'
+```
+
+Use `GET /api/v1/partners/{id}/links` to fetch all landing URLs (with the `via` parameter) that can be shared with a partner.

--- a/src/Controllers/Api/ApiController.php
+++ b/src/Controllers/Api/ApiController.php
@@ -1,0 +1,88 @@
+<?php
+
+namespace Numok\Controllers\Api;
+
+use Numok\Controllers\Controller;
+
+abstract class ApiController extends Controller
+{
+    public function __construct()
+    {
+        $this->handlePreflightRequest();
+    }
+
+    protected function handlePreflightRequest(): void
+    {
+        if (($_SERVER['REQUEST_METHOD'] ?? 'GET') === 'OPTIONS') {
+            $this->respond([], 204);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    protected function getJsonInput(): array
+    {
+        $input = file_get_contents('php://input');
+        if ($input === false || trim($input) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($input, true);
+        if (json_last_error() !== JSON_ERROR_NONE || !is_array($decoded)) {
+            $this->respond([
+                'error' => 'invalid_json',
+                'message' => 'The request body must contain valid JSON.',
+            ], 400);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    protected function respond(array $data, int $status = 200): void
+    {
+        header('Access-Control-Allow-Origin: *');
+        header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS');
+        header('Access-Control-Allow-Headers: Content-Type, Authorization, X-API-Key');
+        header('Access-Control-Max-Age: 86400');
+        header('Content-Type: application/json');
+        http_response_code($status);
+        echo json_encode($data);
+        exit;
+    }
+
+    /**
+     * @param array<int, string> $allowedMethods
+     */
+    protected function methodNotAllowed(array $allowedMethods): void
+    {
+        $this->respond([
+            'error' => 'method_not_allowed',
+            'message' => 'The requested HTTP method is not supported for this endpoint.',
+            'allowed_methods' => $allowedMethods,
+        ], 405);
+    }
+
+    protected function resourceNotFound(string $message = 'Resource not found.'): void
+    {
+        $this->respond([
+            'error' => 'not_found',
+            'message' => $message,
+        ], 404);
+    }
+
+    /**
+     * @param array<string, string> $errors
+     */
+    protected function validationError(array $errors): void
+    {
+        $this->respond([
+            'error' => 'validation_error',
+            'message' => 'The given data was invalid.',
+            'errors' => $errors,
+        ], 422);
+    }
+}

--- a/src/Controllers/Api/PartnerLinksController.php
+++ b/src/Controllers/Api/PartnerLinksController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Numok\Controllers\Api;
+
+use Numok\Database\Database;
+use Numok\Middleware\ApiMiddleware;
+
+class PartnerLinksController extends ApiController
+{
+    public function __construct()
+    {
+        ApiMiddleware::handle();
+        parent::__construct();
+    }
+
+    public function handle(int $partnerId): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        if ($method !== 'GET') {
+            $this->methodNotAllowed(['GET']);
+            return;
+        }
+
+        $partner = Database::query(
+            'SELECT id, email, company_name, status FROM partners WHERE id = ? LIMIT 1',
+            [$partnerId]
+        )->fetch();
+
+        if (!$partner) {
+            $this->resourceNotFound('Partner not found.');
+        }
+
+        $links = Database::query(
+            'SELECT pp.id, pp.tracking_code, pp.status, pp.postback_url, pp.created_at, pp.updated_at, p.id AS program_id, p.name AS program_name, p.landing_page
+             FROM partner_programs pp
+             INNER JOIN programs p ON p.id = pp.program_id
+             WHERE pp.partner_id = ?
+             ORDER BY pp.created_at DESC',
+            [$partnerId]
+        )->fetchAll();
+
+        $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings['app_url'] ?? null);
+
+        $links = array_map(function (array $link) use ($baseUrl): array {
+            $landingPage = $link['landing_page'] ?: $baseUrl;
+            $trackingUrl = rtrim($landingPage, '?&');
+            $separator = str_contains($landingPage, '?') ? '&' : '?';
+            $trackingUrl .= $separator . 'via=' . urlencode($link['tracking_code']);
+
+            return [
+                'partner_program_id' => (int) $link['id'],
+                'program_id' => (int) $link['program_id'],
+                'program_name' => $link['program_name'],
+                'tracking_code' => $link['tracking_code'],
+                'tracking_url' => $trackingUrl,
+                'status' => $link['status'],
+                'postback_url' => $link['postback_url'],
+                'created_at' => $link['created_at'],
+                'updated_at' => $link['updated_at'],
+            ];
+        }, $links);
+
+        $this->respond([
+            'partner' => [
+                'id' => (int) $partner['id'],
+                'email' => $partner['email'],
+                'company_name' => $partner['company_name'],
+                'status' => $partner['status'],
+            ],
+            'links' => $links,
+        ]);
+    }
+}

--- a/src/Controllers/Api/PartnerProgramsController.php
+++ b/src/Controllers/Api/PartnerProgramsController.php
@@ -1,0 +1,196 @@
+<?php
+
+namespace Numok\Controllers\Api;
+
+use Numok\Database\Database;
+use Numok\Middleware\ApiMiddleware;
+
+class PartnerProgramsController extends ApiController
+{
+    public function __construct()
+    {
+        ApiMiddleware::handle();
+        parent::__construct();
+    }
+
+    public function handle(int $partnerId): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+        if ($method === 'GET') {
+            $this->index($partnerId);
+            return;
+        }
+
+        if ($method === 'POST') {
+            $this->store($partnerId);
+            return;
+        }
+
+        $this->methodNotAllowed(['GET', 'POST']);
+    }
+
+    private function index(int $partnerId): void
+    {
+        $partner = Database::query(
+            'SELECT id FROM partners WHERE id = ? LIMIT 1',
+            [$partnerId]
+        )->fetch();
+
+        if (!$partner) {
+            $this->resourceNotFound('Partner not found.');
+        }
+
+        $programs = Database::query(
+            'SELECT pp.id AS partner_program_id, pp.tracking_code, pp.status, pp.postback_url, pp.created_at, pp.updated_at,
+                    p.id AS program_id, p.name AS program_name, p.landing_page
+             FROM partner_programs pp
+             INNER JOIN programs p ON p.id = pp.program_id
+             WHERE pp.partner_id = ?
+             ORDER BY pp.created_at DESC',
+            [$partnerId]
+        )->fetchAll();
+
+        $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings['app_url'] ?? null);
+
+        $programs = array_map(function (array $program) use ($baseUrl): array {
+            $landingPage = $program['landing_page'] ?: $baseUrl;
+            $trackingUrl = rtrim($landingPage, '?&');
+            $separator = str_contains($landingPage, '?') ? '&' : '?';
+            $trackingUrl .= $separator . 'via=' . urlencode($program['tracking_code']);
+
+            return [
+                'partner_program_id' => (int) $program['partner_program_id'],
+                'program_id' => (int) $program['program_id'],
+                'program_name' => $program['program_name'],
+                'tracking_code' => $program['tracking_code'],
+                'tracking_url' => $trackingUrl,
+                'status' => $program['status'],
+                'postback_url' => $program['postback_url'],
+                'created_at' => $program['created_at'],
+                'updated_at' => $program['updated_at'],
+            ];
+        }, $programs);
+
+        $this->respond([
+            'data' => $programs,
+        ]);
+    }
+
+    private function store(int $partnerId): void
+    {
+        $partner = Database::query(
+            'SELECT id FROM partners WHERE id = ? LIMIT 1',
+            [$partnerId]
+        )->fetch();
+
+        if (!$partner) {
+            $this->resourceNotFound('Partner not found.');
+        }
+
+        $input = $this->getJsonInput();
+        $programId = $input['program_id'] ?? null;
+        $postbackUrl = isset($input['postback_url']) ? trim((string) $input['postback_url']) : null;
+        $status = $input['status'] ?? 'active';
+
+        $errors = [];
+        if (!is_numeric($programId)) {
+            $errors['program_id'] = 'The program_id field is required.';
+        }
+        if (!in_array($status, ['active', 'inactive'], true)) {
+            $errors['status'] = 'The status must be either active or inactive.';
+        }
+        if ($postbackUrl !== null && $postbackUrl !== '' && filter_var($postbackUrl, FILTER_VALIDATE_URL) === false) {
+            $errors['postback_url'] = 'The postback_url must be a valid URL when provided.';
+        }
+
+        if ($errors !== []) {
+            $this->validationError($errors);
+        }
+
+        $program = Database::query(
+            'SELECT id, landing_page FROM programs WHERE id = ? AND status = "active" LIMIT 1',
+            [$programId]
+        )->fetch();
+
+        if (!$program) {
+            $this->respond([
+                'error' => 'invalid_program',
+                'message' => 'The specified program is not available.',
+            ], 409);
+        }
+
+        $existing = Database::query(
+            'SELECT id, tracking_code, status, postback_url, created_at, updated_at FROM partner_programs WHERE partner_id = ? AND program_id = ? LIMIT 1',
+            [$partnerId, $programId]
+        )->fetch();
+
+        if ($existing) {
+            $updateData = [];
+            if ($postbackUrl !== null) {
+                $updateData['postback_url'] = $postbackUrl !== '' ? $postbackUrl : null;
+            }
+            if ($status !== $existing['status']) {
+                $updateData['status'] = $status;
+            }
+
+            if ($updateData !== []) {
+                Database::update('partner_programs', $updateData, 'id = ?', [$existing['id']]);
+            }
+
+            $this->respond([
+                'data' => [
+                    'partner_program_id' => (int) $existing['id'],
+                    'program_id' => (int) $programId,
+                    'tracking_code' => $existing['tracking_code'],
+                    'status' => $status,
+                    'postback_url' => $postbackUrl !== null ? ($postbackUrl !== '' ? $postbackUrl : null) : $existing['postback_url'],
+                    'created_at' => $existing['created_at'],
+                    'updated_at' => $existing['updated_at'],
+                ],
+                'message' => 'Partner is already assigned to this program. Existing assignment returned.',
+            ]);
+        }
+
+        $trackingCode = $this->generateTrackingCode();
+
+        $partnerProgramId = Database::insert('partner_programs', [
+            'partner_id' => $partnerId,
+            'program_id' => $programId,
+            'tracking_code' => $trackingCode,
+            'postback_url' => $postbackUrl !== null && $postbackUrl !== '' ? $postbackUrl : null,
+            'status' => $status,
+        ]);
+
+        $assignment = Database::query(
+            'SELECT id, tracking_code, status, postback_url, created_at, updated_at FROM partner_programs WHERE id = ? LIMIT 1',
+            [$partnerProgramId]
+        )->fetch();
+
+        $this->respond([
+            'data' => [
+                'partner_program_id' => (int) $assignment['id'],
+                'program_id' => (int) $programId,
+                'tracking_code' => $assignment['tracking_code'],
+                'status' => $assignment['status'],
+                'postback_url' => $assignment['postback_url'],
+                'created_at' => $assignment['created_at'],
+                'updated_at' => $assignment['updated_at'],
+            ],
+        ], 201);
+    }
+
+    private function generateTrackingCode(): string
+    {
+        do {
+            $code = bin2hex(random_bytes(8));
+            $exists = Database::query(
+                'SELECT id FROM partner_programs WHERE tracking_code = ? LIMIT 1',
+                [$code]
+            )->fetch();
+        } while ($exists);
+
+        return $code;
+    }
+}

--- a/src/Controllers/Api/PartnersController.php
+++ b/src/Controllers/Api/PartnersController.php
@@ -1,0 +1,156 @@
+<?php
+
+namespace Numok\Controllers\Api;
+
+use Numok\Database\Database;
+use Numok\Middleware\ApiMiddleware;
+
+class PartnersController extends ApiController
+{
+    public function __construct()
+    {
+        ApiMiddleware::handle();
+        parent::__construct();
+    }
+
+    public function handle(?int $id = null): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+        if ($id === null) {
+            if ($method === 'GET') {
+                $this->index();
+                return;
+            }
+
+            if ($method === 'POST') {
+                $this->store();
+                return;
+            }
+
+            $this->methodNotAllowed(['GET', 'POST']);
+            return;
+        }
+
+        if ($method === 'GET') {
+            $this->show($id);
+            return;
+        }
+
+        $this->methodNotAllowed(['GET']);
+    }
+
+    private function index(): void
+    {
+        $partners = Database::query(
+            'SELECT id, email, company_name, contact_name, status, payment_email, created_at, updated_at FROM partners ORDER BY created_at DESC'
+        )->fetchAll();
+
+        $partners = array_map(fn(array $partner): array => $this->transformPartner($partner), $partners);
+
+        $this->respond([
+            'data' => $partners,
+        ]);
+    }
+
+    private function show(int $id): void
+    {
+        $partner = Database::query(
+            'SELECT id, email, company_name, contact_name, status, payment_email, created_at, updated_at FROM partners WHERE id = ? LIMIT 1',
+            [$id]
+        )->fetch();
+
+        if (!$partner) {
+            $this->resourceNotFound('Partner not found.');
+        }
+
+        $this->respond([
+            'data' => $this->transformPartner($partner),
+        ]);
+    }
+
+    private function store(): void
+    {
+        $input = $this->getJsonInput();
+
+        $email = filter_var((string) ($input['email'] ?? ''), FILTER_VALIDATE_EMAIL);
+        $companyName = trim((string) ($input['company_name'] ?? ''));
+        $contactName = trim((string) ($input['contact_name'] ?? ''));
+        $password = (string) ($input['password'] ?? '');
+        $paymentEmailRaw = $input['payment_email'] ?? null;
+        $status = $input['status'] ?? 'pending';
+
+        $errors = [];
+        if ($email === false) {
+            $errors['email'] = 'A valid email address is required.';
+        }
+        if ($companyName === '') {
+            $errors['company_name'] = 'The company_name field is required.';
+        }
+        if ($contactName === '') {
+            $errors['contact_name'] = 'The contact_name field is required.';
+        }
+        if ($password === '') {
+            $errors['password'] = 'The password field is required.';
+        }
+        if (!in_array($status, ['pending', 'active', 'rejected', 'suspended'], true)) {
+            $errors['status'] = 'The status must be one of: pending, active, rejected, suspended.';
+        }
+
+        if ($paymentEmailRaw !== null && filter_var((string) $paymentEmailRaw, FILTER_VALIDATE_EMAIL) === false) {
+            $errors['payment_email'] = 'The payment_email must be a valid email address when provided.';
+        }
+
+        if ($errors !== []) {
+            $this->validationError($errors);
+        }
+
+        $existing = Database::query(
+            'SELECT id FROM partners WHERE email = ? LIMIT 1',
+            [$email]
+        )->fetch();
+
+        if ($existing) {
+            $this->respond([
+                'error' => 'partner_exists',
+                'message' => 'A partner with this email already exists.',
+            ], 409);
+        }
+
+        $partnerId = Database::insert('partners', [
+            'email' => $email,
+            'password' => password_hash($password, PASSWORD_BCRYPT),
+            'company_name' => $companyName,
+            'contact_name' => $contactName,
+            'status' => $status,
+            'payment_email' => $paymentEmailRaw !== null ? (string) $paymentEmailRaw : null,
+        ]);
+
+        $partner = Database::query(
+            'SELECT id, email, company_name, contact_name, status, payment_email, created_at, updated_at FROM partners WHERE id = ? LIMIT 1',
+            [$partnerId]
+        )->fetch();
+
+        $this->respond([
+            'data' => $this->transformPartner($partner),
+        ], 201);
+    }
+
+    /**
+     * @param array<string, mixed> $partner
+     * @return array<string, mixed>
+     */
+    private function transformPartner(array $partner): array
+    {
+        return [
+            'id' => (int) $partner['id'],
+            'email' => $partner['email'],
+            'company_name' => $partner['company_name'],
+            'contact_name' => $partner['contact_name'],
+            'status' => $partner['status'],
+            'payment_email' => $partner['payment_email'],
+            'created_at' => $partner['created_at'],
+            'updated_at' => $partner['updated_at'],
+        ];
+    }
+}

--- a/src/Controllers/Api/ProgramsController.php
+++ b/src/Controllers/Api/ProgramsController.php
@@ -1,0 +1,165 @@
+<?php
+
+namespace Numok\Controllers\Api;
+
+use Numok\Database\Database;
+use Numok\Middleware\ApiMiddleware;
+use Numok\Services\ProgramScriptGenerator;
+
+class ProgramsController extends ApiController
+{
+    public function __construct()
+    {
+        ApiMiddleware::handle();
+        parent::__construct();
+    }
+
+    public function handle(?int $id = null): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+        if ($id === null) {
+            if ($method === 'GET') {
+                $this->index();
+                return;
+            }
+
+            if ($method === 'POST') {
+                $this->store();
+                return;
+            }
+
+            $this->methodNotAllowed(['GET', 'POST']);
+            return;
+        }
+
+        if ($method === 'GET') {
+            $this->show($id);
+            return;
+        }
+
+        $this->methodNotAllowed(['GET']);
+    }
+
+    private function index(): void
+    {
+        $programs = Database::query(
+            'SELECT id, name, description, terms, commission_type, commission_value, cookie_days, is_recurring, reward_days, landing_page, status, created_at, updated_at FROM programs ORDER BY created_at DESC'
+        )->fetchAll();
+
+        $programs = array_map(fn(array $program): array => $this->transformProgram($program), $programs);
+
+        $this->respond([
+            'data' => $programs,
+        ]);
+    }
+
+    private function show(int $id): void
+    {
+        $program = Database::query(
+            'SELECT id, name, description, terms, commission_type, commission_value, cookie_days, is_recurring, reward_days, landing_page, status, created_at, updated_at FROM programs WHERE id = ? LIMIT 1',
+            [$id]
+        )->fetch();
+
+        if (!$program) {
+            $this->resourceNotFound('Program not found.');
+        }
+
+        $this->respond([
+            'data' => $this->transformProgram($program),
+        ]);
+    }
+
+    private function store(): void
+    {
+        $input = $this->getJsonInput();
+
+        $name = trim((string) ($input['name'] ?? ''));
+        $commissionType = $input['commission_type'] ?? 'percentage';
+        $commissionValue = $input['commission_value'] ?? null;
+        $cookieDays = $input['cookie_days'] ?? 30;
+        $rewardDays = $input['reward_days'] ?? 0;
+        $landingPage = trim((string) ($input['landing_page'] ?? ''));
+        $isRecurring = filter_var($input['is_recurring'] ?? false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        $errors = [];
+        if ($name === '') {
+            $errors['name'] = 'The name field is required.';
+        }
+
+        if (!in_array($commissionType, ['percentage', 'fixed'], true)) {
+            $errors['commission_type'] = 'The commission_type must be either percentage or fixed.';
+        }
+
+        if (!is_numeric($commissionValue)) {
+            $errors['commission_value'] = 'The commission_value must be numeric.';
+        }
+
+        if (!is_numeric($cookieDays) || (int) $cookieDays < 1) {
+            $errors['cookie_days'] = 'The cookie_days must be a positive integer.';
+        }
+
+        if (!is_numeric($rewardDays) || (int) $rewardDays < 0) {
+            $errors['reward_days'] = 'The reward_days must be zero or a positive integer.';
+        }
+
+        if ($landingPage === '' || filter_var($landingPage, FILTER_VALIDATE_URL) === false) {
+            $errors['landing_page'] = 'A valid landing_page URL is required.';
+        }
+
+        if ($errors !== []) {
+            $this->validationError($errors);
+        }
+
+        $data = [
+            'name' => $name,
+            'description' => $input['description'] ?? null,
+            'terms' => $input['terms'] ?? null,
+            'commission_type' => $commissionType,
+            'commission_value' => round((float) $commissionValue, 2),
+            'cookie_days' => (int) $cookieDays,
+            'is_recurring' => $isRecurring ? 1 : 0,
+            'reward_days' => (int) $rewardDays,
+            'landing_page' => $landingPage,
+            'status' => 'active',
+        ];
+
+        $programId = Database::insert('programs', $data);
+
+        $program = Database::query(
+            'SELECT * FROM programs WHERE id = ? LIMIT 1',
+            [$programId]
+        )->fetch();
+
+        $settings = $this->getSettings();
+        $baseUrl = $this->getBaseUrl($settings['app_url'] ?? null);
+        ProgramScriptGenerator::generate($program, $baseUrl);
+
+        $this->respond([
+            'data' => $this->transformProgram($program),
+        ], 201);
+    }
+
+    /**
+     * @param array<string, mixed> $program
+     * @return array<string, mixed>
+     */
+    private function transformProgram(array $program): array
+    {
+        return [
+            'id' => (int) $program['id'],
+            'name' => $program['name'],
+            'description' => $program['description'],
+            'terms' => $program['terms'],
+            'commission_type' => $program['commission_type'],
+            'commission_value' => (float) $program['commission_value'],
+            'cookie_days' => (int) $program['cookie_days'],
+            'is_recurring' => (bool) $program['is_recurring'],
+            'reward_days' => (int) $program['reward_days'],
+            'landing_page' => $program['landing_page'],
+            'status' => $program['status'],
+            'created_at' => $program['created_at'],
+            'updated_at' => $program['updated_at'],
+        ];
+    }
+}

--- a/src/Controllers/Api/UsersController.php
+++ b/src/Controllers/Api/UsersController.php
@@ -1,0 +1,140 @@
+<?php
+
+namespace Numok\Controllers\Api;
+
+use Numok\Database\Database;
+use Numok\Middleware\ApiMiddleware;
+
+class UsersController extends ApiController
+{
+    public function __construct()
+    {
+        ApiMiddleware::handle();
+        parent::__construct();
+    }
+
+    public function handle(?int $id = null): void
+    {
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+
+        if ($id === null) {
+            if ($method === 'GET') {
+                $this->index();
+                return;
+            }
+
+            if ($method === 'POST') {
+                $this->store();
+                return;
+            }
+
+            $this->methodNotAllowed(['GET', 'POST']);
+            return;
+        }
+
+        if ($method === 'GET') {
+            $this->show($id);
+            return;
+        }
+
+        $this->methodNotAllowed(['GET']);
+    }
+
+    private function index(): void
+    {
+        $users = Database::query(
+            'SELECT id, email, name, is_admin, created_at, updated_at FROM users ORDER BY created_at DESC'
+        )->fetchAll();
+
+        $users = array_map(fn(array $user): array => $this->transformUser($user), $users);
+
+        $this->respond([
+            'data' => $users,
+        ]);
+    }
+
+    private function show(int $id): void
+    {
+        $user = Database::query(
+            'SELECT id, email, name, is_admin, created_at, updated_at FROM users WHERE id = ? LIMIT 1',
+            [$id]
+        )->fetch();
+
+        if (!$user) {
+            $this->resourceNotFound('User not found.');
+        }
+
+        $this->respond([
+            'data' => $this->transformUser($user),
+        ]);
+    }
+
+    private function store(): void
+    {
+        $input = $this->getJsonInput();
+
+        $email = filter_var((string) ($input['email'] ?? ''), FILTER_VALIDATE_EMAIL);
+        $name = trim((string) ($input['name'] ?? ''));
+        $password = (string) ($input['password'] ?? '');
+        $isAdmin = filter_var($input['is_admin'] ?? false, FILTER_VALIDATE_BOOLEAN, FILTER_NULL_ON_FAILURE);
+
+        $errors = [];
+        if ($email === false) {
+            $errors['email'] = 'A valid email address is required.';
+        }
+        if ($name === '') {
+            $errors['name'] = 'The name field is required.';
+        }
+        if ($password === '') {
+            $errors['password'] = 'The password field is required.';
+        }
+
+        if ($errors !== []) {
+            $this->validationError($errors);
+        }
+
+        $existing = Database::query(
+            'SELECT id FROM users WHERE email = ? LIMIT 1',
+            [$email]
+        )->fetch();
+
+        if ($existing) {
+            $this->respond([
+                'error' => 'user_exists',
+                'message' => 'A user with this email already exists.',
+            ], 409);
+        }
+
+        $userId = Database::insert('users', [
+            'email' => $email,
+            'name' => $name,
+            'password' => password_hash($password, PASSWORD_BCRYPT),
+            'is_admin' => $isAdmin ? 1 : 0,
+        ]);
+
+        $user = Database::query(
+            'SELECT id, email, name, is_admin, created_at, updated_at FROM users WHERE id = ? LIMIT 1',
+            [$userId]
+        )->fetch();
+
+        $this->respond([
+            'data' => $this->transformUser($user),
+        ], 201);
+    }
+
+    /**
+     * @param array<string, mixed> $user
+     * @return array<string, mixed>
+     */
+    private function transformUser(array $user): array
+    {
+        return [
+            'id' => (int) $user['id'],
+            'email' => $user['email'],
+            'name' => $user['name'],
+            'is_admin' => (bool) $user['is_admin'],
+            'created_at' => $user['created_at'],
+            'updated_at' => $user['updated_at'],
+        ];
+    }
+}

--- a/src/Middleware/ApiMiddleware.php
+++ b/src/Middleware/ApiMiddleware.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace Numok\Middleware;
+
+class ApiMiddleware {
+    /**
+     * Handle API authentication and preflight requests.
+     *
+     * @param array<string> $allowedMethods
+     */
+    public static function handle(array $allowedMethods = []): void {
+        self::sendCorsHeaders();
+
+        $method = $_SERVER['REQUEST_METHOD'] ?? 'GET';
+        if ($method === 'OPTIONS') {
+            http_response_code(204);
+            exit;
+        }
+
+        if ($allowedMethods !== [] && !in_array($method, $allowedMethods, true)) {
+            http_response_code(405);
+            header('Content-Type: application/json');
+            echo json_encode([
+                'error' => 'method_not_allowed',
+                'message' => 'The requested HTTP method is not supported for this endpoint.',
+                'allowed_methods' => $allowedMethods,
+            ]);
+            exit;
+        }
+
+        $token = self::extractToken();
+        $validTokens = self::getValidTokens();
+
+        if ($validTokens === []) {
+            http_response_code(500);
+            header('Content-Type: application/json');
+            echo json_encode([
+                'error' => 'api_token_not_configured',
+                'message' => 'API access is disabled because no API tokens are configured.',
+            ]);
+            exit;
+        }
+
+        if ($token === null || !self::isTokenValid($token, $validTokens)) {
+            http_response_code(401);
+            header('Content-Type: application/json');
+            echo json_encode([
+                'error' => 'unauthorized',
+                'message' => 'A valid API token is required to access this resource.',
+            ]);
+            exit;
+        }
+    }
+
+    private static function sendCorsHeaders(): void {
+        header('Access-Control-Allow-Origin: *');
+        header('Access-Control-Allow-Methods: GET, POST, PUT, PATCH, DELETE, OPTIONS');
+        header('Access-Control-Allow-Headers: Content-Type, Authorization, X-API-Key');
+        header('Access-Control-Max-Age: 86400');
+    }
+
+    private static function extractToken(): ?string {
+        $headers = function_exists('getallheaders') ? getallheaders() : [];
+
+        if (isset($headers['Authorization'])) {
+            $parts = explode(' ', trim((string) $headers['Authorization']));
+            if (count($parts) === 2 && strcasecmp($parts[0], 'Bearer') === 0) {
+                return $parts[1];
+            }
+        }
+
+        if (isset($headers['X-API-Key'])) {
+            return (string) $headers['X-API-Key'];
+        }
+
+        if (isset($_SERVER['HTTP_AUTHORIZATION'])) {
+            $parts = explode(' ', trim((string) $_SERVER['HTTP_AUTHORIZATION']));
+            if (count($parts) === 2 && strcasecmp($parts[0], 'Bearer') === 0) {
+                return $parts[1];
+            }
+        }
+
+        if (isset($_SERVER['HTTP_X_API_KEY'])) {
+            return (string) $_SERVER['HTTP_X_API_KEY'];
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int, string>
+     */
+    private static function getValidTokens(): array {
+        global $config;
+
+        $tokens = $config['api']['tokens'] ?? [];
+        if (!is_array($tokens)) {
+            return [];
+        }
+
+        return array_values(array_filter(array_map('trim', $tokens), static fn($value) => $value !== ''));
+    }
+
+    /**
+     * @param array<int, string> $validTokens
+     */
+    private static function isTokenValid(string $token, array $validTokens): bool {
+        foreach ($validTokens as $validToken) {
+            if ($validToken === '') {
+                continue;
+            }
+
+            if (str_starts_with($validToken, '$2y$') || str_starts_with($validToken, '$argon2')) {
+                if (password_verify($token, $validToken)) {
+                    return true;
+                }
+                continue;
+            }
+
+            if (hash_equals($validToken, $token)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}


### PR DESCRIPTION
## Summary
- add an API middleware and base controller that enforce token authentication and JSON responses
- expose REST endpoints to manage users, programs, partners, partner links, and partner-program assignments
- document API setup in the README and configuration example

## Testing
- for file in src/Middleware/ApiMiddleware.php src/Controllers/Api/*.php; do php -l $file; done

------
https://chatgpt.com/codex/tasks/task_e_68d2ea794d8c8321a8e2981c18903551